### PR TITLE
Notification date time format changed

### DIFF
--- a/src/Components/Notifications/CustomerNotifications.jsx
+++ b/src/Components/Notifications/CustomerNotifications.jsx
@@ -10,6 +10,7 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Divider from "@material-ui/core/Divider";
+import moment from "moment";
 
 const useStyles = makeStyles((theme) => ({
   typography: {
@@ -94,7 +95,7 @@ export default function CustomerNotifications(props) {
                 {noti.serName} reserved for {noti.bookedDate} cancelled
                 sucessfully
                 <br />
-                <small>in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />
@@ -117,7 +118,7 @@ export default function CustomerNotifications(props) {
               <small>
                 {noti.serName} reserved for {noti.bookedDate} sucessfully
                 <br />
-                <small>created in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />

--- a/src/Components/Notifications/ServiceNotifications.jsx
+++ b/src/Components/Notifications/ServiceNotifications.jsx
@@ -10,6 +10,7 @@ import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
 import Divider from "@material-ui/core/Divider";
+import moment from "moment";
 
 const useStyles = makeStyles((theme) => ({
   typography: {
@@ -113,7 +114,7 @@ export default function ServiceNotifications(props) {
                 Your service {noti.serName} booked for {noti.bookedDate}{" "}
                 cancelled by {noti.custName}
                 <br />
-                <small>in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />
@@ -137,7 +138,7 @@ export default function ServiceNotifications(props) {
                 {noti.serName} reserved for {noti.bookedDate} cancelled
                 sucessfully
                 <br />
-                <small>in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />
@@ -161,7 +162,7 @@ export default function ServiceNotifications(props) {
                 Your service {noti.serName} booked for {noti.bookedDate} by{" "}
                 {noti.custName}
                 <br />
-                <small>created in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />
@@ -184,7 +185,7 @@ export default function ServiceNotifications(props) {
               <small>
                 {noti.serName} reserved for {noti.bookedDate} sucessfully
                 <br />
-                <small>created in {noti.createdDate}</small>
+                <small>{moment(noti.createdDate).fromNow()}</small>
               </small>
             </Typography>
             <Divider />


### PR DESCRIPTION
Notification date-time format changed to a format that shows the action date based on the current date as shown in the below screenshot. This PR will resolve the issue #15 

![notific](https://user-images.githubusercontent.com/48345668/117777178-f825ea80-b259-11eb-80c1-116e58c14aec.PNG)
